### PR TITLE
Add optional `/bootstrap` option for read-only Docker volume support

### DIFF
--- a/slim/02-optional-bootstrap.sh
+++ b/slim/02-optional-bootstrap.sh
@@ -1,0 +1,9 @@
+# Allow mounting a read-only volume with ZNC configs/files. The files in
+# '/bootstrap' will be copied to '/znc-data' at runtime since ZNC expects write
+# access. This is useful for k8s ConfigMaps/Secrets which only allow mounting
+# read-only volumes (for now).
+# Note, to use a mounted directory on the host machine you will need to ensure
+# you run 'chown -R 100' (the znc uid) prior to running the container.
+if [ -d /bootstrap ]; then
+  cp -RT /bootstrap /znc-data
+fi

--- a/slim/Dockerfile
+++ b/slim/Dockerfile
@@ -53,9 +53,11 @@ RUN set -x \
 COPY entrypoint.sh /
 COPY 00-try-sh.sh /startup-sequence/
 COPY 01-options.sh /startup-sequence/
+COPY 02-optional-bootstrap.sh /startup-sequence/
 COPY 20-chown.sh /startup-sequence/
 COPY 99-launch.sh /startup-sequence/
 
+VOLUME /bootstrap # See 02-optional-bootstrap.sh
 VOLUME /znc-data
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This is useful for mounting read-only volumes (e.g. k8s ConfigMap/Secrets).

ZNC expects write access so this allows mounting a volume as read-only then copying the data to `/znc-data` at runtime.

I tested this locally, but I am by no means an expert so this "feature" may be way off base. It helped me with my k8s project though :smile:.

Feel free to edit anything/everything and thank you for everything you've done so far.